### PR TITLE
Fix workflow

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -53,6 +53,7 @@ jobs:
           restore-keys: npm-packages-
 
       - run: yarn
+      - run: yarn build
       # Check to make sure that docs built into www.
 #      - run: ls -lah $GITHUB_WORKSPACE/www
 
@@ -71,7 +72,6 @@ jobs:
       - name: Main branch preparations
         if: github.ref == format('refs/heads/{0}', env.MAIN_BRANCH)
         run: |
-          yarn build --base=./
           cp -a $GITHUB_WORKSPACE/dist/* $GITHUB_WORKSPACE/gh-pages
 
       # If develop branch:
@@ -80,7 +80,6 @@ jobs:
       - name: Develop branch preparations
         if: github.ref == format('refs/heads/{0}', env.DEVELOP_BRANCH)
         run: |
-          yarn build --base=./latest/
           rm -rf $GITHUB_WORKSPACE/gh-pages/latest
           mv $GITHUB_WORKSPACE/dist $GITHUB_WORKSPACE/gh-pages/latest
 


### PR DESCRIPTION
Noticing the current build of `latest` seems to have a duplicate `latest/latest` in the path to the JS file that gets generated. This attempts to use the vite.config.js setting instead of hard-coding. We'll see what happens.